### PR TITLE
Fix futures

### DIFF
--- a/rss_routes/src/lib.rs
+++ b/rss_routes/src/lib.rs
@@ -31,7 +31,8 @@ use futures::prelude::*;
 
 use hyper::header::ContentLength;
 use hyper::Error as HyperError;
-use hyper::server::{Request, Response, Service, StatusCode};
+use hyper::server::{Request, Response, Service};
+use hyper::{StatusCode};
 
 static PHRASE: &'static str = "Hello, World!";
 
@@ -52,13 +53,14 @@ impl RouterService {
 
     fn route(&self, req: Request) -> ResponseFuture {
         let stat_file = self.static_.call(req)
-        .map_err(|_err| {
-            Box::new(future::ok(
-              Response::new()
-              .with_status(StatusCode::NotFound)
-              .with_header(ContentLength(HTML404.len() as u64))
-              .with_body(HTML404)
-              ))}).flatten();
+            .or_else(|_err| {
+                future::ok(
+                  Response::new()
+                  .with_status(StatusCode::NotFound)
+                  .with_header(ContentLength(HTML404.len() as u64))
+                  .with_body(HTML404)
+                )
+            });
         Box::new(stat_file)
     }
 }


### PR DESCRIPTION
So...

- `flatten()` didn't do what I expected. Removed it. I guess Flatten would have been useful if you had had a `Future<Item=Future,...>`.
- `map_err` was the wrong one to call. `map_err` is the "in case of an error, return this error instead" while `or_else` is the "In case of an error, try this and see if it goes better".
- The `Box<>` outside the future is needed to return it so that was a good change. The `Box<>` inside the Success result wasn't needed so I removed that. It didn't break the build and the thing compiled fine even with the `Box<>` within the `or_else`, but as it's not needed better get rid of it.